### PR TITLE
extract the global position

### DIFF
--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -75,8 +75,8 @@ def _get_position(name: str, reg: geant4.Registry) -> list:
     pv = reg.physicalVolumeDict[name]
     local_pos = pv.position
 
-    n_mothers = -1
-
+    n_mothers = 1
+    
     while n_mothers > 0:
         mothers = find_mother_physical_volume(pv, reg)
         n_mothers = len(mothers)

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -77,7 +77,7 @@ def _get_position(name: str, reg: geant4.Registry) -> list:
     local_pos = pv.position
 
     n_mothers = 1
-    
+
     while n_mothers > 0:
         mothers = find_mother_physical_volume(pv, reg)
         n_mothers = len(mothers)

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -91,7 +91,7 @@ def _get_position(name: str, reg: geant4.Registry) -> list:
                 raise RuntimeError(msg)
 
             local_pos += mothers[0].position
-            
+
             pv = mothers[0]
 
     return local_pos.eval()
@@ -112,7 +112,7 @@ def get_hpges(
         for name in det_list
     }
 
-    pos = {name: _get_position(name,reg) for name in det_list}
+    pos = {name: _get_position(name, reg) for name in det_list}
 
     return hpges, pos
 

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -9,6 +9,7 @@ import pyg4ometry.geant4 as pg4
 import pygeomhpges
 import pygeomtools
 from pyg4ometry import geant4
+
 from revertex import core
 
 log = logging.getLogger(__name__)

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -91,6 +91,8 @@ def _get_position(name: str, reg: geant4.Registry) -> list:
                 raise RuntimeError(msg)
 
             local_pos += mothers[0].position
+            
+            pv = mothers[0]
 
     return local_pos.eval()
 
@@ -110,7 +112,7 @@ def get_hpges(
         for name in det_list
     }
 
-    pos = {name: _get_position(name, reg) for name in det_list}
+    pos = {name: _get_position(name,reg) for name in det_list}
 
     return hpges, pos
 

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import pyg4ometry.geant4 as pg4
 import pygeomhpges
 import pygeomtools
-
+from pyg4ometry import geant4
 from revertex import core
 
 log = logging.getLogger(__name__)
@@ -54,6 +54,46 @@ def read_input_beta_csv(path: str, **kwargs) -> tuple[np.ndarray, np.ndarray]:
     return np.genfromtxt(path, **kwargs).T[0], np.genfromtxt(path, **kwargs).T[1]
 
 
+def find_mother_physical_volume(
+    pv: geant4.PhysicalVolume, registry: geant4.Registry
+) -> list:
+    """Find the mother physical volume."""
+    mothers = []
+
+    for other_pv in registry.physicalVolumeDict.values():
+        lv = other_pv.logicalVolume
+
+        if pv in lv.daughterVolumes:
+            mothers.append(other_pv)
+
+    return mothers
+
+
+def _get_position(name: str, reg: geant4.Registry) -> list:
+    """Get the position from the GDML"""
+
+    pv = reg.physicalVolumeDict[name]
+    local_pos = pv.position
+
+    n_mothers = -1
+
+    while n_mothers > 0:
+        mothers = find_mother_physical_volume(pv, reg)
+        n_mothers = len(mothers)
+
+        if len(mothers) > 1:
+            msg = "Only support finding global position if every volume is only placed once."
+            raise RuntimeError(msg)
+        if len(mothers) == 1:
+            if mothers[0].rotation.eval() != [0, 0, 0]:
+                msg = "Only support finding global position without rotations"
+                raise RuntimeError(msg)
+
+            local_pos += mothers[0].position
+
+    return local_pos.eval()
+
+
 def get_hpges(
     reg: pg4.geant4.registry, detectors: str | list[str]
 ) -> tuple[dict, dict]:
@@ -69,7 +109,7 @@ def get_hpges(
         for name in det_list
     }
 
-    pos = {name: phy_vol_dict[name].position.eval() for name in det_list}
+    pos = {name: _get_position(name, reg) for name in det_list}
 
     return hpges, pos
 

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -70,10 +70,10 @@ def find_mother_physical_volume(
     return mothers
 
 
-def _get_position(name: str, reg: geant4.Registry) -> list:
-    """Get the position from the GDML"""
+def _get_position(pv_name: str, reg: geant4.Registry) -> list:
+    """Get the global position of a physical volume from the GDML"""
 
-    pv = reg.physicalVolumeDict[name]
+    pv = reg.physicalVolumeDict[pv_name]
     local_pos = pv.position
 
     n_mothers = 1

--- a/src/revertex/utils.py
+++ b/src/revertex/utils.py
@@ -55,10 +55,10 @@ def read_input_beta_csv(path: str, **kwargs) -> tuple[np.ndarray, np.ndarray]:
     return np.genfromtxt(path, **kwargs).T[0], np.genfromtxt(path, **kwargs).T[1]
 
 
-def find_mother_physical_volume(
+def find_mother_physical_volumes(
     pv: geant4.PhysicalVolume, registry: geant4.Registry
-) -> list:
-    """Find the mother physical volume."""
+) -> list[geant4.PhysicalVolume]:
+    """Find the mother physical volumes."""
     mothers = []
 
     for other_pv in registry.physicalVolumeDict.values():
@@ -79,7 +79,7 @@ def _get_position(pv_name: str, reg: geant4.Registry) -> list:
     n_mothers = 1
 
     while n_mothers > 0:
-        mothers = find_mother_physical_volume(pv, reg)
+        mothers = find_mother_physical_volumes(pv, reg)
         n_mothers = len(mothers)
 
         if len(mothers) > 1:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,15 @@ def test_hpges():
     assert utils.get_surface_weights(hpges, "nplus")[0] == 1.0
 
 
+def test_position():
+    test_file_dir = Path(__file__).parent
+    gdml = f"{test_file_dir}/test_files/geom.gdml"
+
+    reg = pyg4ometry.gdml.Reader(gdml).getRegistry()
+
+    print(utils._get_position("B99000A", reg))
+
+
 def test_borehole(test_data_configs):
     reg = geant4.Registry()
     hpge_IC = pygeomhpges.make_hpge(test_data_configs + "/V99000A.yaml", registry=reg)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,7 +54,10 @@ def test_position():
 
     reg = pyg4ometry.gdml.Reader(gdml).getRegistry()
 
-    print(utils._get_position("B99000A", reg))
+    # B99000A is placed at (-5, 0, -3) cm in LAr, which is at the origin
+    assert utils._get_position("B99000A", reg) == [-50.0, 0.0, -30.0]
+    # V99000A is placed at (5, 0, -3) cm in LAr, which is at the origin
+    assert utils._get_position("V99000A", reg) == [50.0, 0.0, -30.0]
 
 
 def test_borehole(test_data_configs):


### PR DESCRIPTION
- [x] Rename `find_mother_physical_volume` to `find_mother_physical_volumes` with `list[geant4.PhysicalVolume]` return type
- [x] Update call site in `_get_position` to use renamed function
- [x] Write a proper assertion-based `test_position` test (asserts B99000A at [-50, 0, -30] mm and V99000A at [50, 0, -30] mm)

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.